### PR TITLE
Sort collection dates by date when querying

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,12 +1,17 @@
 # Züri Trash Bot
 
-Züri Trash Bot is a convenient way to query paper. cardboard, and textile collection dates for people living in Zurich. The bot also support querying dates for the next cargo tram and E-tram.
+Züri Trash Bot is a [Telegram](https://telegram.org) bot, which offers a convenient way to query paper :newspaper:, cardboard :package:, and textile :shirt: collection dates for people living in Zurich. The bot also support querying dates :calendar: for the next cargo tram and E-tram :train:.
 
-## Setup
+## Usage
 
-* clone the git repository
-* create a virtual environment
-* install the requirements from `requirement.txt` (in the virtual environment)
-* copy `config.ini.example` to `config.ini` and configure your telegram bot token
-* run `trashbot.py` from the `src` folder
+Visit https://t.me/zh_trashbot or use `@zh_trashbot` directly from within Telegram.
 
+## Deployment
+
+You don't need to deploy the bot to use it. For using the bot, just follow the link above. If - for whatever reason - you want to deploy (a copy of) this bot, you will need to:
+
+- clone this repository,
+- create a virtual environment (use python 3.6 or later),
+- install the dependencies (into your virtual environment): `pip install -r requirements.txt`,
+- copy `config.ini.example` to `config.ini`, get a [Telegram bot token](https://core.telegram.org/bots#creating-a-new-bot) and configure it in `config.ini`,
+- run `python trashbot.py`  from within the `src/` folder (or submit a PR to fix the fact that we currently have a hard-coded relative path to the config file)

--- a/src/trashbot.py
+++ b/src/trashbot.py
@@ -6,7 +6,7 @@ import logging
 import re
 import urllib.request
 
-from datetime import datetime, date
+from datetime import datetime
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import CallbackQueryHandler, CommandHandler,\
     ConversationHandler, Filters, MessageHandler, PicklePersistence, Updater
@@ -92,8 +92,8 @@ def button(update, context):
     limit = 1
 
     baseurl = "http://openerz.metaodi.ch/api/calendar"
-    openerz = "%s/%s.json?zip=%s&start=%s&limit=%s" % (baseurl, query.data,
-                                                       zip, today, limit)
+    openerz = "%s/%s.json?sort=date&zip=%s&start=%s&limit=%s" % (baseurl,
+     query.data, zip, today, limit)
 
     with urllib.request.urlopen(openerz) as url:
         data = json.loads(url.read().decode())


### PR DESCRIPTION
Added an option to sort the collection dates by date when querying. This seems not to be the default and generated wrong results. Fixed now.