### PR TITLE
Fix name resolution in case no collection is found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zh-trashbot"
-version = "1.2.2"
+version = "1.2.3"
 description = "Züri Trash Bot is a convenient way to query paper and cardboard collection dates for people living in Zürich."
 requires-python = ">=3.8"
 dependencies = [

--- a/src/zh_trashbot/bot.py
+++ b/src/zh_trashbot/bot.py
@@ -34,9 +34,12 @@ E_unsure = "\U0001F615"
 E_wave = "\U0001F44B"
 
 CHOOSE, HANDLE_LIMIT, ZIPCODE = range(3)
-CURRENT_VERSION = "1.2.2"
+CURRENT_VERSION = "1.2.3"
 
 WhatsNew = {
+    "1.2.3": [
+        "Fix name resolution when no collection is found",
+    ],
     "1.2.2": [
         "Software & project maintenance",
         "Fixed typos",
@@ -187,7 +190,7 @@ def queryCollectionAPI(choice, user_data):
                 "message if the new year's data isn't publicly available "\
                 "yet.\n\n"\
                 "If you think your zip code is wrong, use /start to "\
-                "configure a new one." % (E_cry, name[query.data], zip)
+                "configure a new one." % (name[choice], E_cry, zip)
             return notFound
 
         nextDate = ""

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "zh-trashbot"
-version = "1.2.1"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "python-telegram-bot" },


### PR DESCRIPTION
## :bug: Bugfix release

In case no collection dates are found (this happens especially at the end of a year when next year's data isn't yet available), `@zh_trashbot` would hang. This was due to an unsafe lookup in the `name` dictionary, effectively crashing the request.

Found during deployment testing of the [1.2.2 release](https://github.com/romanc/zh_trashbot/releases/tag/v1.2.2).